### PR TITLE
feat(#1): Resilient async job manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+jobs/

--- a/README.md
+++ b/README.md
@@ -1,39 +1,116 @@
 # Resilient Claude Code Skill
 
-**The "Anti-Crash" Coding Runner for OpenClaw.**
+**Persistent, detached coding jobs for OpenClaw.**
 
-Most Claude Code wrappers just run `exec('claude ...')`. If your agent turn times out, or the gateway restarts, or the API hangs—**your coding task dies.**
+Most Claude Code wrappers run `exec('claude ...')`. If your agent turn times out, the gateway restarts, or the API hangs — your coding task dies.
 
-This skill treats coding tasks as **Persistent, Detached Jobs**.
+This skill treats coding tasks as **persistent, detached jobs** using the `@anthropic-ai/claude-agent-sdk`.
 
-## Why this exists
+## Why This Exists
 
-### 1. Decoupled Lifecycle
-- **Problem:** Agent turns have timeouts (e.g., 900s). Coding tasks take 20+ minutes.
-- **Solution:** This skill starts a `claude` process, **detaches it** from the agent session, and returns a `jobId`. The agent can check back later.
+### Decoupled Lifecycle
+Agent turns have timeouts (e.g., 900s). Coding tasks take 20+ minutes. This skill starts a Claude agent process, **detaches it** from the agent session, and returns a `jobId`. The agent checks back later.
 
-### 2. Restart Survival
-- **Problem:** If you restart OpenClaw (maintenance, crash, update), child processes usually get `SIGKILL`.
-- **Solution:** Spawns processes in a separate process group. Uses PID tracking files on disk. If the gateway reboots, it **re-acquires the running job** instead of killing it.
+### Restart Survival
+If you restart OpenClaw (maintenance, crash, update), child processes usually get killed. This skill spawns processes in a separate process group with PID tracking on disk. On reboot, it **re-acquires running jobs** instead of losing them.
 
-### 3. Rate Limit Intelligence
-- **Problem:** Generic wrappers treat any pause as a hang.
-- **Solution:** Parses logs to distinguish between "Claude is thinking" (good) and "API 429/503" (bad), bubbling precise status to the orchestrator.
+### Rate Limit Intelligence
+Generic wrappers treat any pause as a hang. This skill distinguishes between "Claude is thinking" and "API 429/503", bubbling precise status to the orchestrator.
 
 ## Architecture
 
-[ Agent ] -> (Start Job) -> [ Skill Manager ] -> (Spawn & Detach) -> [ Claude Code CLI ]
-                                      |
-                               (Write PID/Log)
-                                      v
-                                 [ Disk State ]
+```
+[ OpenClaw Agent ] -> (SKILL.md instructions) -> [ exec: node scripts/run.mjs ]
+                                                        |
+                                                  (Spawn detached job)
+                                                        |
+                                                  [ Claude Agent SDK ]
+                                                        |
+                                                  (Write state to disk)
+                                                        v
+                                                  [ jobs/<jobId>/ ]
+                                                    ├── meta.json    (status, timestamps, pid)
+                                                    ├── output.log   (streaming output)
+                                                    └── result.json  (final result when done)
+```
 
-1. Agent calls `start_coding(...)` -> gets `job_123`.
-2. Agent ends turn.
-3. Cron/Heartbeat calls `check_job('job_123')`.
-4. Skill reads log tail and process status from disk.
-5. Returns status: `running` | `completed` | `failed`.
+1. Agent calls `start` — gets a `jobId` and `pid`.
+2. Agent turn ends. The coding job keeps running.
+3. Agent polls `status` on next turn.
+4. Skill reads process status and log tail from disk.
+5. Returns: `running` | `completed` | `failed` | `killed`.
 
 ## Usage
 
-See [SKILL.md](SKILL.md) for tool definitions.
+### Start a job
+
+```bash
+node scripts/run.mjs start \
+  --prompt "Read TASK.md and implement. Run tests." \
+  --cwd /path/to/project \
+  --job-id task-137
+```
+
+### Check status
+
+```bash
+node scripts/run.mjs status --job-id task-137
+```
+
+### Get logs
+
+```bash
+node scripts/run.mjs logs --job-id task-137 --tail 50
+```
+
+### Get result
+
+```bash
+node scripts/run.mjs result --job-id task-137
+```
+
+### List all jobs
+
+```bash
+node scripts/run.mjs list
+```
+
+### Kill a job
+
+```bash
+node scripts/run.mjs kill --job-id task-137
+```
+
+## File Structure
+
+```
+openclaw-skill-claude-code/
+├── SKILL.md              # OpenClaw skill instructions
+├── README.md             # Documentation
+├── package.json          # Dependencies
+├── scripts/
+│   ├── run.mjs           # CLI entry point
+│   ├── job-manager.mjs   # Job lifecycle management
+│   └── worker.mjs        # Detached worker process
+└── jobs/                 # Runtime state (gitignored)
+    └── <jobId>/
+        ├── meta.json
+        ├── output.log
+        └── result.json
+```
+
+## Configuration
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `ANTHROPIC_API_KEY` | Yes | — | Claude API key |
+| `CLAUDE_SKILL_JOBS_DIR` | No | `<skill-dir>/jobs` | Directory for job state |
+| `CLAUDE_SKILL_MODEL` | No | SDK default | Override the model |
+
+## How It Works
+
+**Job Manager** (`scripts/job-manager.mjs`): Manages the job lifecycle — `start`, `status`, `result`, `logs`, `list`, `kill`. Spawns workers as detached processes and tracks them by PID on disk.
+
+**Worker** (`scripts/worker.mjs`): Runs in a detached process. Streams the Claude Agent SDK `query()` iterator, writing output to `output.log` and final results to `result.json`. Handles SIGTERM gracefully and detects rate limits.
+
+**CLI** (`scripts/run.mjs`): Thin command-line wrapper over the job manager. All output is structured JSON.

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,43 +1,109 @@
 ---
 name: claude-code
-description: Run coding tasks using the Claude Code CLI. Use this skill when you need to perform complex coding tasks, refactoring, or multi-file edits that require an agentic coding loop.
+description: Run coding tasks as persistent, detached jobs using the Claude Agent SDK. Jobs survive agent timeouts, gateway restarts, and API hangs.
 ---
 
 # Claude Code Skill
 
-This skill provides a wrapper around the `claude` CLI tool to execute agentic coding tasks.
+This skill runs coding tasks as **persistent, detached jobs** using the `@anthropic-ai/claude-agent-sdk`. Unlike raw `exec claude` calls, jobs survive agent turn timeouts, gateway restarts, and API rate limits.
 
-## Usage
+## Starting a coding task
 
-To run a coding task:
-
-1.  **Define the task**: Create a detailed `TASK.md` file in the project root if the task is complex.
-2.  **Run Claude Code**: Use the `exec` tool to invoke the wrapper command.
-
-### Command Pattern
+Use `exec` to start a detached job. It returns immediately with a `jobId`.
 
 ```bash
-~/.local/bin/claude --dangerously-skip-permissions -p "YOUR PROMPT HERE"
+node {{skill_dir}}/scripts/run.mjs start \
+  --prompt "Read TASK.md and implement. Run tests." \
+  --cwd /path/to/project \
+  --job-id task-137
 ```
 
-**Crucial Arguments:**
-- `--dangerously-skip-permissions`: Required to run without interactive confirmation prompts.
-- `-p "..."`: The prompt describing the task.
+**Arguments:**
+- `--prompt` (required): The task description for Claude.
+- `--cwd` (required): The working directory for the coding task.
+- `--job-id` (required): A unique identifier for this job.
+- `--model` (optional): Override the model (defaults to SDK default).
 
-### Best Practices
+**Returns JSON:**
+```json
+{ "jobId": "task-137", "pid": 12345, "status": "running" }
+```
 
-- **Context**: Claude Code automatically reads files in the current directory. Ensure you are in the correct project root before running.
-- **Verification**: Claude Code can run tests. Include "Run tests" in your prompt to verify changes.
-- **Timeout**: Agentic coding takes time. When calling `exec`, set a long `yieldMs` (e.g., `120000` or more) to allow the process to run in the background.
+## Checking status
 
-## Examples
+Poll job status to see if it's still running, completed, or failed.
 
-**Fixing a bug:**
 ```bash
-~/.local/bin/claude --dangerously-skip-permissions -p "Fix the race condition in src/api/client.ts. Run npm test to verify."
+node {{skill_dir}}/scripts/run.mjs status --job-id task-137
 ```
 
-**Implementing a feature from a spec:**
-```bash
-~/.local/bin/claude --dangerously-skip-permissions -p "Read TASK.md and implement the user profile API. Use the existing patterns in lib/trpc."
+**Returns JSON:**
+```json
+{
+  "jobId": "task-137",
+  "pid": 12345,
+  "status": "running",
+  "startedAt": "2025-01-01T00:00:00.000Z",
+  "endedAt": null,
+  "error": null,
+  "rateLimited": false
+}
 ```
+
+**Status values:** `running`, `completed`, `failed`, `killed`, `not_found`
+
+If `rateLimited` is `true`, the job hit API rate limits — this is a temporary condition, not a hang.
+
+## Getting logs
+
+Read the last N lines of streaming output from the job.
+
+```bash
+node {{skill_dir}}/scripts/run.mjs logs --job-id task-137 --tail 50
+```
+
+## Getting the result
+
+Once status is `completed`, retrieve the final result.
+
+```bash
+node {{skill_dir}}/scripts/run.mjs result --job-id task-137
+```
+
+**Returns JSON:**
+```json
+{
+  "jobId": "task-137",
+  "status": "completed",
+  "result": "...",
+  "cost_usd": 0.05,
+  "duration_ms": 120000,
+  "num_turns": 8
+}
+```
+
+## Listing all jobs
+
+```bash
+node {{skill_dir}}/scripts/run.mjs list
+```
+
+## Killing a job
+
+```bash
+node {{skill_dir}}/scripts/run.mjs kill --job-id task-137
+```
+
+## Best Practices
+
+- **Unique job IDs**: Use descriptive IDs like `issue-42` or `feat-auth-v2` to track jobs.
+- **Poll status**: After starting a job, check status periodically. Jobs can take 5-30 minutes.
+- **Check logs on failure**: If status is `failed`, read logs to understand what went wrong.
+- **Rate limits are normal**: If `rateLimited` is true, the SDK is handling retries automatically.
+- **Verification**: Include "Run tests" in your prompt to have Claude verify its own changes.
+
+## Environment
+
+- `ANTHROPIC_API_KEY` — required (the skill checks for this and fails fast with a clear error if missing).
+- `CLAUDE_SKILL_JOBS_DIR` — optional, defaults to `<skill_dir>/jobs`.
+- `CLAUDE_SKILL_MODEL` — optional, overrides the default model.

--- a/TASK.md
+++ b/TASK.md
@@ -1,0 +1,178 @@
+# TASK: Build Resilient Claude Code Skill for OpenClaw (#1)
+
+## Context
+This is an OpenClaw skill that wraps the `@anthropic-ai/claude-agent-sdk` (the official Claude Agent SDK) to run coding tasks as persistent, detached jobs. The current method (`exec claude --dangerously-skip-permissions`) is fragile — jobs die on gateway restart, timeouts, or API hangs.
+
+## Architecture
+
+```
+[ OpenClaw Agent ] -> (SKILL.md instructions) -> [ exec: node scripts/run.mjs ]
+                                                        |
+                                                  (Spawn detached job)
+                                                        |
+                                                  [ Claude Agent SDK ]
+                                                        |
+                                                  (Write state to disk)
+                                                        v
+                                                  [ jobs/<jobId>/ ]
+                                                    ├── meta.json    (status, timestamps, pid)
+                                                    ├── output.log   (streaming output)
+                                                    └── result.json  (final result when done)
+```
+
+## SDK Reference
+
+The official SDK is `@anthropic-ai/claude-agent-sdk` (v0.2.42). TypeScript usage:
+
+```typescript
+import { query } from "@anthropic-ai/claude-agent-sdk";
+
+for await (const message of query({
+  prompt: "Fix the bug in auth.py",
+  options: {
+    allowedTools: ["Read", "Edit", "Bash", "Glob", "Grep"],
+    permissionMode: "acceptEdits", // Auto-approve file edits
+  }
+})) {
+  if (message.type === "assistant" && message.message?.content) {
+    for (const block of message.message.content) {
+      if ("text" in block) console.log(block.text);
+      else if ("name" in block) console.log(`Tool: ${block.name}`);
+    }
+  } else if (message.type === "result") {
+    console.log(`Done: ${message.subtype}`);
+  }
+}
+```
+
+Auth: Set `ANTHROPIC_API_KEY` env var. The SDK reads it automatically.
+
+Available tools: `Read`, `Write`, `Edit`, `Bash`, `Glob`, `Grep`, `WebSearch`, `WebFetch`.
+
+## Implementation
+
+### 1. Package Setup
+Create `package.json` with dependencies:
+- `@anthropic-ai/claude-agent-sdk`
+- No other runtime deps needed
+
+### 2. Job Manager (`scripts/job-manager.mjs`)
+Core module that manages job lifecycle:
+
+```javascript
+// start(jobId, prompt, cwd, options) → spawns detached process
+// status(jobId) → reads meta.json, checks if PID alive
+// result(jobId) → reads result.json
+// logs(jobId, tail) → reads last N lines of output.log
+// list() → lists all jobs with status
+// kill(jobId) → sends SIGTERM to PID
+```
+
+**State directory**: `jobs/<jobId>/`
+- `meta.json`: `{ jobId, pid, status, prompt, cwd, startedAt, endedAt, error }`
+- `output.log`: Streaming text output from the agent
+- `result.json`: Final result text (written on completion)
+
+**Detached spawn**: The job manager spawns `node scripts/worker.mjs <jobId>` as a detached child process (`{ detached: true, stdio: 'ignore' }`) and immediately unrefs it. The worker runs independently.
+
+**PID tracking**: On startup, `status()` checks if the PID in `meta.json` is still alive (`process.kill(pid, 0)`). If the process died without updating status, mark as `failed`.
+
+### 3. Worker (`scripts/worker.mjs`)
+Runs in a detached process. Receives `jobId` as argv:
+
+1. Read `jobs/<jobId>/meta.json` for prompt and cwd
+2. `process.chdir(cwd)`
+3. Stream `query()` from the Agent SDK
+4. Write each message to `output.log` (append)
+5. On completion: write `result.json`, update `meta.json` status to `completed`
+6. On error: update `meta.json` status to `failed`, write error details
+7. Handle SIGTERM gracefully
+
+**Rate limit detection**: Watch for 429/503 patterns in error messages. Set a `rateLimited` flag in `meta.json` so the orchestrator knows it's not a hang.
+
+### 4. CLI Entry Points (`scripts/run.mjs`)
+Simple CLI wrappers for the job manager:
+
+```bash
+# Start a job
+node scripts/run.mjs start --prompt "Fix the bug" --cwd /path/to/project --job-id my-job
+
+# Check status
+node scripts/run.mjs status --job-id my-job
+
+# Get logs (last 50 lines)
+node scripts/run.mjs logs --job-id my-job --tail 50
+
+# Get result
+node scripts/run.mjs result --job-id my-job
+
+# List all jobs
+node scripts/run.mjs list
+
+# Kill a job
+node scripts/run.mjs kill --job-id my-job
+```
+
+Return JSON to stdout for structured output.
+
+### 5. SKILL.md
+Update the skill instructions to use the new scripts instead of raw `exec claude`:
+
+```markdown
+## Starting a coding task
+Use `exec` to run:
+\`\`\`bash
+node /path/to/skill/scripts/run.mjs start \
+  --prompt "Read TASK.md and implement. Run tests." \
+  --cwd /path/to/project \
+  --job-id task-137
+\`\`\`
+
+## Checking status
+\`\`\`bash
+node /path/to/skill/scripts/run.mjs status --job-id task-137
+\`\`\`
+
+## Getting results
+\`\`\`bash
+node /path/to/skill/scripts/run.mjs result --job-id task-137
+\`\`\`
+```
+
+### 6. README.md
+Update with architecture diagram, usage examples, and configuration.
+
+## Configuration
+
+The skill reads these env vars:
+- `ANTHROPIC_API_KEY` — required (Claude API key)
+- `CLAUDE_SKILL_JOBS_DIR` — optional, defaults to `<skill-dir>/jobs`
+- `CLAUDE_SKILL_MODEL` — optional, defaults to SDK default
+
+## File Structure
+```
+openclaw-skill-claude-code/
+├── SKILL.md              # OpenClaw skill instructions
+├── README.md             # Documentation
+├── package.json          # Dependencies
+├── scripts/
+│   ├── run.mjs           # CLI entry point
+│   ├── job-manager.mjs   # Job lifecycle management
+│   └── worker.mjs        # Detached worker process
+└── jobs/                 # Runtime state (gitignored)
+    └── <jobId>/
+        ├── meta.json
+        ├── output.log
+        └── result.json
+```
+
+## Verification
+- `npm install` succeeds
+- `node scripts/run.mjs start --prompt "What files are here?" --cwd . --job-id test-1` starts a job
+- `node scripts/run.mjs status --job-id test-1` shows status
+- `node scripts/run.mjs list` shows all jobs
+- Job survives if parent process exits
+- Handles missing ANTHROPIC_API_KEY gracefully (clear error message)
+
+## Branch
+`feat/1-resilient-job-manager`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,332 @@
+{
+  "name": "openclaw-skill-claude-code",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "openclaw-skill-claude-code",
+      "version": "1.0.0",
+      "dependencies": {
+        "@anthropic-ai/claude-agent-sdk": "^0.2.42"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk": {
+      "version": "0.2.42",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.42.tgz",
+      "integrity": "sha512-/CugP7AjP57Dqtl2sbsDtxdbpQoPKIhjyF5WrTViGu4NHQdM+UikrRs4MhZ2jeotiC5R7iK9ZUN9SiBgcZ8oLw==",
+      "license": "SEE LICENSE IN README.md",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "^0.33.5",
+        "@img/sharp-darwin-x64": "^0.33.5",
+        "@img/sharp-linux-arm": "^0.33.5",
+        "@img/sharp-linux-arm64": "^0.33.5",
+        "@img/sharp-linux-x64": "^0.33.5",
+        "@img/sharp-linuxmusl-arm64": "^0.33.5",
+        "@img/sharp-linuxmusl-x64": "^0.33.5",
+        "@img/sharp-win32-x64": "^0.33.5"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
+      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
+      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
+      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
+      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
+      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
+      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
+      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
+      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
+      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
+      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.0.5"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
+      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
+      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
+      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
+      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
+      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "openclaw-skill-claude-code",
+  "version": "1.0.0",
+  "description": "Resilient Claude Code skill for OpenClaw — persistent, detached coding jobs",
+  "type": "module",
+  "scripts": {
+    "start": "node scripts/run.mjs"
+  },
+  "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.2.42"
+  }
+}

--- a/scripts/job-manager.mjs
+++ b/scripts/job-manager.mjs
@@ -1,0 +1,174 @@
+import { spawn } from "node:child_process";
+import { readFile, writeFile, mkdir, readdir } from "node:fs/promises";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SKILL_DIR = join(__dirname, "..");
+const JOBS_DIR = process.env.CLAUDE_SKILL_JOBS_DIR || join(SKILL_DIR, "jobs");
+
+async function ensureJobDir(jobId) {
+  const dir = join(JOBS_DIR, jobId);
+  await mkdir(dir, { recursive: true });
+  return dir;
+}
+
+function metaPath(jobId) {
+  return join(JOBS_DIR, jobId, "meta.json");
+}
+
+function outputPath(jobId) {
+  return join(JOBS_DIR, jobId, "output.log");
+}
+
+function resultPath(jobId) {
+  return join(JOBS_DIR, jobId, "result.json");
+}
+
+function isPidAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readJson(path) {
+  const data = await readFile(path, "utf-8");
+  return JSON.parse(data);
+}
+
+async function writeJson(path, data) {
+  await writeFile(path, JSON.stringify(data, null, 2) + "\n");
+}
+
+export async function start(jobId, prompt, cwd, options = {}) {
+  const dir = await ensureJobDir(jobId);
+
+  const meta = {
+    jobId,
+    pid: null,
+    status: "starting",
+    prompt,
+    cwd,
+    model: options.model || process.env.CLAUDE_SKILL_MODEL || undefined,
+    allowedTools: options.allowedTools || undefined,
+    startedAt: new Date().toISOString(),
+    endedAt: null,
+    error: null,
+    rateLimited: false,
+  };
+
+  await writeJson(metaPath(jobId), meta);
+  await writeFile(outputPath(jobId), "");
+
+  const workerPath = join(__dirname, "worker.mjs");
+  const child = spawn("node", [workerPath, jobId], {
+    detached: true,
+    stdio: "ignore",
+    cwd: SKILL_DIR,
+    env: { ...process.env },
+  });
+
+  child.unref();
+
+  meta.pid = child.pid;
+  meta.status = "running";
+  await writeJson(metaPath(jobId), meta);
+
+  return { jobId, pid: child.pid, status: "running" };
+}
+
+export async function status(jobId) {
+  let meta;
+  try {
+    meta = await readJson(metaPath(jobId));
+  } catch {
+    return { jobId, status: "not_found" };
+  }
+
+  if (meta.status === "running" && meta.pid) {
+    if (!isPidAlive(meta.pid)) {
+      meta.status = "failed";
+      meta.error = "Process exited unexpectedly";
+      meta.endedAt = new Date().toISOString();
+      await writeJson(metaPath(jobId), meta);
+    }
+  }
+
+  return {
+    jobId: meta.jobId,
+    pid: meta.pid,
+    status: meta.status,
+    startedAt: meta.startedAt,
+    endedAt: meta.endedAt,
+    error: meta.error,
+    rateLimited: meta.rateLimited,
+  };
+}
+
+export async function result(jobId) {
+  try {
+    return await readJson(resultPath(jobId));
+  } catch {
+    const s = await status(jobId);
+    return { jobId, status: s.status, result: null };
+  }
+}
+
+export async function logs(jobId, tail = 50) {
+  try {
+    const content = await readFile(outputPath(jobId), "utf-8");
+    const lines = content.split("\n");
+    const sliced = lines.slice(-tail).join("\n");
+    return { jobId, lines: lines.length, tail: sliced };
+  } catch {
+    return { jobId, lines: 0, tail: "" };
+  }
+}
+
+export async function list() {
+  let entries;
+  try {
+    entries = await readdir(JOBS_DIR, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const jobs = [];
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      const s = await status(entry.name);
+      jobs.push(s);
+    }
+  }
+  return jobs;
+}
+
+export async function kill(jobId) {
+  let meta;
+  try {
+    meta = await readJson(metaPath(jobId));
+  } catch {
+    return { jobId, killed: false, error: "Job not found" };
+  }
+
+  if (!meta.pid) {
+    return { jobId, killed: false, error: "No PID recorded" };
+  }
+
+  if (!isPidAlive(meta.pid)) {
+    return { jobId, killed: false, error: "Process already dead" };
+  }
+
+  try {
+    process.kill(meta.pid, "SIGTERM");
+    meta.status = "killed";
+    meta.endedAt = new Date().toISOString();
+    await writeJson(metaPath(jobId), meta);
+    return { jobId, killed: true };
+  } catch (err) {
+    return { jobId, killed: false, error: err.message };
+  }
+}

--- a/scripts/run.mjs
+++ b/scripts/run.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+
+import { start, status, result, logs, list, kill } from "./job-manager.mjs";
+
+function parseArgs(args) {
+  const parsed = {};
+  for (let i = 0; i < args.length; i++) {
+    if (args[i].startsWith("--")) {
+      const key = args[i].slice(2);
+      const next = args[i + 1];
+      if (next && !next.startsWith("--")) {
+        parsed[key] = next;
+        i++;
+      } else {
+        parsed[key] = true;
+      }
+    }
+  }
+  return parsed;
+}
+
+function output(data) {
+  process.stdout.write(JSON.stringify(data, null, 2) + "\n");
+}
+
+function die(message) {
+  output({ error: message });
+  process.exit(1);
+}
+
+const [command, ...rest] = process.argv.slice(2);
+const args = parseArgs(rest);
+
+switch (command) {
+  case "start": {
+    const prompt = args.prompt;
+    const cwd = args.cwd || process.cwd();
+    const jobId = args["job-id"];
+
+    if (!prompt) die("--prompt is required");
+    if (!jobId) die("--job-id is required");
+
+    const options = {};
+    if (args.model) options.model = args.model;
+
+    const res = await start(jobId, prompt, cwd, options);
+    output(res);
+    break;
+  }
+
+  case "status": {
+    const jobId = args["job-id"];
+    if (!jobId) die("--job-id is required");
+    output(await status(jobId));
+    break;
+  }
+
+  case "result": {
+    const jobId = args["job-id"];
+    if (!jobId) die("--job-id is required");
+    output(await result(jobId));
+    break;
+  }
+
+  case "logs": {
+    const jobId = args["job-id"];
+    if (!jobId) die("--job-id is required");
+    const tail = parseInt(args.tail, 10) || 50;
+    output(await logs(jobId, tail));
+    break;
+  }
+
+  case "list": {
+    output(await list());
+    break;
+  }
+
+  case "kill": {
+    const jobId = args["job-id"];
+    if (!jobId) die("--job-id is required");
+    output(await kill(jobId));
+    break;
+  }
+
+  default:
+    die(
+      `Unknown command: ${command || "(none)"}. ` +
+      `Available: start, status, result, logs, list, kill`
+    );
+}

--- a/scripts/worker.mjs
+++ b/scripts/worker.mjs
@@ -1,0 +1,183 @@
+import { readFile, writeFile, appendFile } from "node:fs/promises";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SKILL_DIR = join(__dirname, "..");
+const JOBS_DIR = process.env.CLAUDE_SKILL_JOBS_DIR || join(SKILL_DIR, "jobs");
+
+const jobId = process.argv[2];
+if (!jobId) {
+  console.error("Usage: node worker.mjs <jobId>");
+  process.exit(1);
+}
+
+const metaFile = join(JOBS_DIR, jobId, "meta.json");
+const outputFile = join(JOBS_DIR, jobId, "output.log");
+const resultFile = join(JOBS_DIR, jobId, "result.json");
+
+async function readMeta() {
+  return JSON.parse(await readFile(metaFile, "utf-8"));
+}
+
+async function writeMeta(meta) {
+  await writeFile(metaFile, JSON.stringify(meta, null, 2) + "\n");
+}
+
+async function log(text) {
+  await appendFile(outputFile, text + "\n");
+}
+
+let shuttingDown = false;
+
+process.on("SIGTERM", async () => {
+  shuttingDown = true;
+  await log("[worker] Received SIGTERM, shutting down gracefully...");
+  const meta = await readMeta();
+  meta.status = "killed";
+  meta.endedAt = new Date().toISOString();
+  await writeMeta(meta);
+  process.exit(0);
+});
+
+async function run() {
+  const meta = await readMeta();
+
+  if (!process.env.ANTHROPIC_API_KEY) {
+    meta.status = "failed";
+    meta.error = "ANTHROPIC_API_KEY environment variable is not set";
+    meta.endedAt = new Date().toISOString();
+    await writeMeta(meta);
+    await log("[worker] ERROR: ANTHROPIC_API_KEY not set");
+    process.exit(1);
+  }
+
+  await log(`[worker] Starting job ${jobId}`);
+  await log(`[worker] Prompt: ${meta.prompt}`);
+  await log(`[worker] CWD: ${meta.cwd}`);
+
+  let queryFn;
+  try {
+    const sdk = await import("@anthropic-ai/claude-agent-sdk");
+    queryFn = sdk.query;
+  } catch (err) {
+    meta.status = "failed";
+    meta.error = `Failed to load SDK: ${err.message}`;
+    meta.endedAt = new Date().toISOString();
+    await writeMeta(meta);
+    await log(`[worker] ERROR: ${meta.error}`);
+    process.exit(1);
+  }
+
+  const options = {
+    cwd: meta.cwd,
+    permissionMode: "bypassPermissions",
+    allowDangerouslySkipPermissions: true,
+  };
+
+  if (meta.model) {
+    options.model = meta.model;
+  }
+
+  if (meta.allowedTools) {
+    options.allowedTools = meta.allowedTools;
+  }
+
+  let resultText = "";
+
+  try {
+    const q = queryFn({ prompt: meta.prompt, options });
+
+    for await (const message of q) {
+      if (shuttingDown) break;
+
+      if (message.type === "assistant" && message.message?.content) {
+        for (const block of message.message.content) {
+          if ("text" in block) {
+            await log(block.text);
+            resultText += block.text + "\n";
+          } else if ("name" in block) {
+            await log(`[tool] ${block.name}`);
+          }
+        }
+      } else if (message.type === "result") {
+        if (message.subtype === "success") {
+          await log(`[worker] Completed successfully`);
+          resultText = message.result || resultText;
+
+          const resultData = {
+            jobId,
+            status: "completed",
+            result: resultText,
+            cost_usd: message.total_cost_usd,
+            duration_ms: message.duration_ms,
+            num_turns: message.num_turns,
+          };
+          await writeFile(resultFile, JSON.stringify(resultData, null, 2) + "\n");
+
+          meta.status = "completed";
+          meta.endedAt = new Date().toISOString();
+          await writeMeta(meta);
+        } else {
+          const errorMsg = message.errors?.join("; ") || message.subtype;
+          await log(`[worker] Error: ${errorMsg}`);
+
+          meta.status = "failed";
+          meta.error = errorMsg;
+          meta.endedAt = new Date().toISOString();
+          await writeMeta(meta);
+
+          const resultData = {
+            jobId,
+            status: "failed",
+            error: errorMsg,
+            result: resultText || null,
+            cost_usd: message.total_cost_usd,
+            duration_ms: message.duration_ms,
+          };
+          await writeFile(resultFile, JSON.stringify(resultData, null, 2) + "\n");
+        }
+      } else if (message.type === "assistant" && message.error) {
+        const errType = message.error;
+        if (errType === "rate_limit") {
+          meta.rateLimited = true;
+          await writeMeta(meta);
+          await log("[worker] Rate limited, SDK will retry...");
+        }
+      }
+    }
+  } catch (err) {
+    const errMsg = err.message || String(err);
+    await log(`[worker] Fatal error: ${errMsg}`);
+
+    const isRateLimit = /429|rate.limit|503|overloaded/i.test(errMsg);
+    meta.status = "failed";
+    meta.error = errMsg;
+    meta.rateLimited = isRateLimit;
+    meta.endedAt = new Date().toISOString();
+    await writeMeta(meta);
+
+    const resultData = {
+      jobId,
+      status: "failed",
+      error: errMsg,
+      result: resultText || null,
+    };
+    await writeFile(resultFile, JSON.stringify(resultData, null, 2) + "\n");
+    process.exit(1);
+  }
+}
+
+run().catch(async (err) => {
+  try {
+    const meta = await readMeta();
+    meta.status = "failed";
+    meta.error = err.message || String(err);
+    meta.endedAt = new Date().toISOString();
+    await writeMeta(meta);
+    await log(`[worker] Unhandled error: ${meta.error}`);
+  } catch {
+    // Can't even write meta, just exit
+  }
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
Replaces fragile `exec claude --dangerously-skip-permissions` with a persistent, detached job architecture using the official `@anthropic-ai/claude-agent-sdk`.

### What's included:
- **Job manager** (`scripts/job-manager.mjs`) — start/status/result/logs/list/kill with detached spawning and PID tracking
- **Worker** (`scripts/worker.mjs`) — detached process streaming SDK `query()`, writes to disk state, handles SIGTERM, detects rate limits
- **CLI** (`scripts/run.mjs`) — structured JSON output for all commands
- **Updated SKILL.md** — job-based instructions replacing raw exec
- **Updated README.md** — architecture, usage, configuration

### Key features:
- Jobs survive gateway restarts (detached process groups)
- PID tracking + re-acquisition on reboot
- Rate limit detection (429/503) with distinct status
- Structured JSON output for agent consumption

Closes #1